### PR TITLE
Update stylesheet.css

### DIFF
--- a/views/default/css/framework/gallery/stylesheet.css
+++ b/views/default/css/framework/gallery/stylesheet.css
@@ -1247,6 +1247,6 @@ body.gallery-state-loading:before {
   padding: 0;
   border: 0;
 }
-.taggable {
+.gallery-media-full .taggable {
 	width:100%!important;
 }


### PR DESCRIPTION
Added a few tiny css changes to add some more responsiveness.
- The '.gallery-media-full' padding makes sure that the comment, etc...fields are not 'right against the left border'.
- The extra line '.taggable' overrides the default width of the image, when resizing (or mobile viewing) the photo was not resizing along with the screen.
- The lineheight change (550px -> 100%) in .gallery-media-full-view makes sure there isn't a gap as the main image resizes.

Feel free to merge, or not if you don't like it.
Cheers, Dries
