### PR TITLE
fix for 'visible' unlike icon

### DIFF
--- a/views/default/css/framework/gallery/stylesheet.css
+++ b/views/default/css/framework/gallery/stylesheet.css
@@ -1254,6 +1254,6 @@ li.elgg-state-loading [class*="gallery-icon-"]:before,
   padding: 0;
   border: 0;
 }
-.hidden, .elgg-page .hidden {
+.elgg-menu-entity .hidden {
     display: none!important;
 }

--- a/views/default/css/framework/gallery/stylesheet.css
+++ b/views/default/css/framework/gallery/stylesheet.css
@@ -1254,3 +1254,6 @@ li.elgg-state-loading [class*="gallery-icon-"]:before,
   padding: 0;
   border: 0;
 }
+.hidden, .elgg-page .hidden {
+    display: none!important;
+}


### PR DESCRIPTION
Due to the fact that all li are set to 'inline-block' in Hypegallerys css file, the unlike icon becomes visible as well.
Adding the !important tag to the .hidden class overrides this beheaviour.

I don't know if this is your preferable fix, but it solves it :)
